### PR TITLE
chore(dependabot): configure auto-merge to dev branch for all updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    target-branch: 'dev'
     open-pull-requests-limit: 10
     versioning-strategy: increase
     groups:
@@ -23,6 +24,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    target-branch: 'dev'
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'ci'


### PR DESCRIPTION
This PR updates the Dependabot configuration to ensure all updates are routed and auto-merged to the  branch instead of . This aligns with our intended workflow, where  acts as the integration branch for all dependency updates before merging to .