### PR TITLE
fix(ci): use GITHUB_TOKEN and enforce squash merge for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto.yml
+++ b/.github/workflows/dependabot-auto.yml
@@ -1,5 +1,6 @@
 name: Dependabot Auto-Merge
-on: pull_request_target
+on:
+  pull_request_target:
 
 permissions:
   pull-requests: write
@@ -14,17 +15,17 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: '${{ secrets.GH_TOKEN }}'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for Dependabot PRs
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-major'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GH_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-approve all updates
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GH_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Changes implemented

- Use `${{ secrets.GITHUB_TOKEN }}` instead of a manually created PAT for Dependabot auto-merge workflow
- Enforce squash merge for Dependabot PRs to maintain a linear commit history

## Tasks completed

- [x] Updated `.github/workflows/dependabot-auto.yml` to use the automatic GITHUB_TOKEN
- [x] Changed merge strategy to `--squash` for Dependabot PRs
- [x] Validated workflow with local tests

## Type of change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [x] 🔧 Configuration

## Quality assurance

- [ ] 🧪 BDD/TDD approach followed
- [ ] ✅ Unit tests added/updated
- [ ] 🔄 Integration tests added/updated
- [ ] 📚 Storybook stories updated
- [x] 🧠 Manual testing performed
- [x] 🔍 All existing tests pass

## Additional notes

This PR ensures that Dependabot PRs are auto-merged using squash to keep the commit history linear, and uses the recommended GITHUB_TOKEN for improved security and maintainability.

---
