### PR TITLE
ci(github): add pnpm installation step to release workflow (#117)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
- Ensure pnpm is installed before running dependency installation in GitHub Actions
- Fixes 'pnpm: command not found' error during release pipeline