### PR TITLE
refactor(ci): consolidate CI jobs and streamline pipeline (#122)

### DIFF
--- a/.github/workflows/execute-ci-pipeline.yml
+++ b/.github/workflows/execute-ci-pipeline.yml
@@ -1,4 +1,4 @@
-name: Execute CI Pipeline
+name: Monorepo CI
 
 on:
   push:
@@ -6,19 +6,9 @@ on:
   pull_request:
 
 jobs:
-  clean-pnpm:
-    name: Clean global pnpm install and cache
+  ci:
     runs-on: ubuntu-latest
-    steps:
-      - name: Remove pnpm install dir
-        run: rm -rf /home/runner/setup-pnpm || true
-      - name: Remove pnpm global cache
-        run: rm -rf ~/.pnpm-store || true
 
-  eslint:
-    name: ESLint
-    needs: clean-pnpm
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -47,174 +37,22 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
-      - name: Run ESLint
+      - name: Lint
         run: pnpm lint
 
-  prettier:
-    name: Prettier
-    needs: clean-pnpm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm config get store-dir)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
-
-      - name: Check formatting
+      - name: Format check
         run: pnpm format
-
-  typescript:
-    name: TypeScript
-    needs: clean-pnpm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm config get store-dir)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
-
-      # Build only the tools package (and its dependencies) to ensure type declarations are available for the CLI
-      - name: Build tools package (required for CLI type-check)
-        run: pnpm --filter @vite-powerflow/tools... build
-
-      # Type-check only the CLI package (and its dependencies)
-      - name: Run CLI type check
-        run: pnpm --filter @vite-powerflow/create... type-check
-
-  commitlint:
-    name: Commitlint
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Commitlint validation
-        uses: wagoid/commitlint-github-action@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  root-scripts-quality:
-    name: Root Scripts Quality
-    needs: clean-pnpm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm config get store-dir)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
 
       - name: Check root scripts quality
         run: pnpm run validate:root-scripts
 
-  build:
-    needs: [eslint, prettier, typescript, commitlint, root-scripts-quality]
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm config get store-dir)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
-
-      - name: Build
+      - name: Build all packages (TurboRepo)
         run: pnpm build
+
+      - name: Type-check all packages (TurboRepo)
+        run: pnpm type-check
+
+      - name: Test all packages (TurboRepo)
+        run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
- Renamed CI pipeline from "Execute CI Pipeline" to "Monorepo CI" for clarity.
- Consolidated multiple jobs into a single "ci" job, removing redundant steps.
- Updated dependency installation to use `--frozen-lockfile` for consistency.
- Renamed linting and formatting steps for better clarity.
- Added TurboRepo commands to build, type-check, and test all packages in one job.