### PR TITLE
fix(release): ensure lockfile is updated correctly

### DIFF
--- a/.changeset/changeset-cli.md
+++ b/.changeset/changeset-cli.md
@@ -2,6 +2,6 @@
 '@vite-powerflow/create': minor
 ---
 
-anchor: 94a482f1de9ba500d119c5fc4143f37de38fe26a
+anchor: 898125a4aadd3baeeab70d8ed4a08f0446677b64
 
 Hardens the project scaffolding process. The CLI now dynamically replaces internal `workspace:*` dependencies with their correct local package versions in the generated `package.json`. This crucial change ensures that new projects are immediately installable and functional outside the monorepo, fixing `pnpm install` failures.

--- a/.changeset/changeset-starter.md
+++ b/.changeset/changeset-starter.md
@@ -2,7 +2,7 @@
 '@vite-powerflow/starter': patch
 ---
 
-anchor: 94a482f1de9ba500d119c5fc4143f37de38fe26a
+anchor: 898125a4aadd3baeeab70d8ed4a08f0446677b64
 baseline: 668ab2e8f19ec5a066bfdba3e5f2713f29078ff5
 
 Improves the developer experience and tooling robustness. The `lint-staged` configuration has been corrected to use portable, auto-fixing commands (`prettier --write`), ensuring a smoother pre-commit workflow. The end-to-end test script also now provides better visual feedback during setup.

--- a/.changeset/changeset-utils.md
+++ b/.changeset/changeset-utils.md
@@ -2,6 +2,6 @@
 '@vite-powerflow/utils': patch
 ---
 
-anchor: 94a482f1de9ba500d119c5fc4143f37de38fe26a
+anchor: 898125a4aadd3baeeab70d8ed4a08f0446677b64
 
 Refactors internal tooling by migrating scripts from a legacy 'tools' package. This change improves the project's internal structure and testability for shared utilities.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "sync:starter-to-template": "tsx scripts/sync-starter-to-template.ts",
     "set-cli-template-baseline": "tsx scripts/set-cli-template-baseline.ts",
     "release:validate-versions": "tsx scripts/validate-published-versions.ts",
-    "release:prepare": "changeset version",
+    "release:prepare": "changeset version && pnpm install --offline",
     "release:publish": "pnpm build && changeset publish && pnpm sync:starter-to-template && pnpm set-cli-template-baseline && pnpm release:validate-versions",
     "ci:local": "git clean -fdx && pnpm install --frozen-lockfile && CI=true ./scripts/ci.sh"
   },

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -143,6 +143,6 @@
   },
   "starterSource": {
     "commit": "668ab2e8f19ec5a066bfdba3e5f2713f29078ff5",
-    "syncedAt": "2025-09-02T16:21:54.904Z"
+    "syncedAt": "2025-09-03T09:47:26.508Z"
   }
 }


### PR DESCRIPTION
This PR merges the definitive fix for the release workflow. The 'release:prepare' script is now configured to run 'pnpm install --offline' after 'changeset version', ensuring the lockfile is always synchronized. This solves the '--frozen-lockfile' errors in CI.