### PR TITLE
fix: resolve Starter package desynchronization with DRY release constants

### DIFF
--- a/.changeset/refactor-release-constants.md
+++ b/.changeset/refactor-release-constants.md
@@ -1,0 +1,13 @@
+---
+'@vite-powerflow/cli': patch
+---
+
+refactor: centralize release constants and improve DRY compliance
+
+- Create constants/release-constants.ts as single source of truth for release commit messages and PR titles
+- Add shared git-utils.ts with reusable commit detection logic for baseline calculation
+- Update GitHub Actions workflow to dynamically read constants from TypeScript source
+- Refactor baseline calculation scripts to use shared utilities instead of duplicated git log commands
+- Fix baseline calculation timing issue by detecting latest release commit instead of using HEAD
+
+This resolves the root cause of Starter package desynchronization and ensures all release-related constants are maintained in one location.

--- a/.changeset/refactor-release-constants.md
+++ b/.changeset/refactor-release-constants.md
@@ -2,7 +2,7 @@
 '@vite-powerflow/create': patch
 ---
 
-anchor: dfd3414b4c48c23517bbf4643831da78d0aa8e46
+anchor: fae6ba8e7376ef21ceac98d8fd2e7b67b7609a1a
 
 refactor: centralize release constants and improve DRY compliance
 

--- a/.changeset/refactor-release-constants.md
+++ b/.changeset/refactor-release-constants.md
@@ -1,8 +1,8 @@
 ---
-'@vite-powerflow/cli': patch
+'@vite-powerflow/create': patch
 ---
 
-anchor: 8b618105af9f26a0134a098ea84c0d0edd071710
+anchor: dfd3414b4c48c23517bbf4643831da78d0aa8e46
 
 refactor: centralize release constants and improve DRY compliance
 

--- a/.changeset/refactor-release-constants.md
+++ b/.changeset/refactor-release-constants.md
@@ -2,6 +2,8 @@
 '@vite-powerflow/cli': patch
 ---
 
+anchor: 8b618105af9f26a0134a098ea84c0d0edd071710
+
 refactor: centralize release constants and improve DRY compliance
 
 - Create constants/release-constants.ts as single source of truth for release commit messages and PR titles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,15 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Get Release Constants
+        id: constants
+        run: |
+          echo "Reading release constants..."
+          CONSTANTS=$(npx tsx constants/release-constants.ts --export-json)
+          echo "constants=$CONSTANTS" >> $GITHUB_OUTPUT
+          echo "COMMIT_MESSAGE=$(echo "$CONSTANTS" | jq -r '.COMMIT_MESSAGE')" >> $GITHUB_OUTPUT
+          echo "PR_TITLE=$(echo "$CONSTANTS" | jq -r '.PR_TITLE')" >> $GITHUB_OUTPUT
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -77,12 +86,12 @@ jobs:
           publish: pnpm run release:publish
           # This command will be run to create the PR.
           version: pnpm run release:prepare
-          # IMPORTANT: The following values are also used in syncChecker.ts and syncReporter.ts
+          # IMPORTANT: The following values are read from scripts/release-constants.ts
           # To ensure correct sync status detection across the project, keep these values in sync
           # vite-powerflow-sync/src/core/syncReporter.ts
           # vite-powerflow-sync/src/core/syncChecker.ts
-          commit: 'chore: release new versions'
-          title: 'Version Packages'
+          commit: ${{ steps.constants.outputs.COMMIT_MESSAGE }}
+          title: ${{ steps.constants.outputs.PR_TITLE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # ← Uses the secret from npm-publish environment

--- a/constants/release-constants.ts
+++ b/constants/release-constants.ts
@@ -1,0 +1,21 @@
+// Release constants - keep in sync across all files
+// Used by: .github/workflows/release.yml, scripts/git-utils.ts, packages/vite-powerflow-sync
+
+export const RELEASE_CONSTANTS = {
+  COMMIT_MESSAGE: 'chore: release new versions',
+  PR_TITLE: 'Version Packages',
+} as const;
+
+// Export JSON when called directly (for GitHub Actions)
+if (import.meta.url === `file://${process.argv[1]}` && process.argv.includes('--export-json')) {
+  console.log(
+    JSON.stringify(
+      {
+        COMMIT_MESSAGE: RELEASE_CONSTANTS.COMMIT_MESSAGE,
+        PR_TITLE: RELEASE_CONSTANTS.PR_TITLE,
+      },
+      null,
+      2
+    )
+  );
+}

--- a/constants/release-constants.ts
+++ b/constants/release-constants.ts
@@ -9,13 +9,9 @@ export const RELEASE_CONSTANTS = {
 // Export JSON when called directly (for GitHub Actions)
 if (import.meta.url === `file://${process.argv[1]}` && process.argv.includes('--export-json')) {
   console.log(
-    JSON.stringify(
-      {
-        COMMIT_MESSAGE: RELEASE_CONSTANTS.COMMIT_MESSAGE,
-        PR_TITLE: RELEASE_CONSTANTS.PR_TITLE,
-      },
-      null,
-      2
-    )
+    JSON.stringify({
+      COMMIT_MESSAGE: RELEASE_CONSTANTS.COMMIT_MESSAGE,
+      PR_TITLE: RELEASE_CONSTANTS.PR_TITLE,
+    })
   );
 }

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -143,6 +143,6 @@
   },
   "starterSource": {
     "commit": "3c3c5f60743cbc51faf55504c35e61d8002817b5",
-    "syncedAt": "2025-09-03T20:57:21.601Z"
+    "syncedAt": "2025-09-03T21:16:14.233Z"
   }
 }

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -143,6 +143,6 @@
   },
   "starterSource": {
     "commit": "3c3c5f60743cbc51faf55504c35e61d8002817b5",
-    "syncedAt": "2025-09-03T21:16:14.233Z"
+    "syncedAt": "2025-09-03T21:31:17.099Z"
   }
 }

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -143,6 +143,6 @@
   },
   "starterSource": {
     "commit": "3c3c5f60743cbc51faf55504c35e61d8002817b5",
-    "syncedAt": "2025-09-03T20:44:07.730Z"
+    "syncedAt": "2025-09-03T20:53:38.308Z"
   }
 }

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -143,6 +143,6 @@
   },
   "starterSource": {
     "commit": "3c3c5f60743cbc51faf55504c35e61d8002817b5",
-    "syncedAt": "2025-09-03T20:53:38.308Z"
+    "syncedAt": "2025-09-03T20:57:21.601Z"
   }
 }

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -142,7 +142,7 @@
     ]
   },
   "starterSource": {
-    "commit": "668ab2e8f19ec5a066bfdba3e5f2713f29078ff5",
-    "syncedAt": "2025-09-03T14:57:44.012Z"
+    "commit": "3c3c5f60743cbc51faf55504c35e61d8002817b5",
+    "syncedAt": "2025-09-03T20:44:07.730Z"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,8 +681,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       '@vite-powerflow/utils':
-        specifier: ^0.0.1
-        version: 0.0.1
+        specifier: ^0.0.2
+        version: 0.0.2
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -3930,8 +3930,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vite-powerflow/utils@0.0.1':
-    resolution: {integrity: sha512-hZv9nQSY6w5sljel7r0lbN0uohAfeC2UjefGPh+aUg3Gm+iv7oQIuKHtLoOr3/dNIi4wSXFqM5FHksa1z10HQA==}
+  '@vite-powerflow/utils@0.0.2':
+    resolution: {integrity: sha512-8hz3k2k7Iew3/O5J+SaYAoeI1AziIo0CDNCoYTy7FTWzzqOX6gq0EHryDe0ka6r/DbsnyY6Xo5f5nltgh0PsRQ==}
 
   '@vitejs/plugin-react-swc@3.10.2':
     resolution: {integrity: sha512-xD3Rdvrt5LgANug7WekBn1KhcvLn1H3jNBfJRL3reeOIua/WnZOEV5qi5qIBq5T8R0jUDmRtxuvk4bPhzGHDWw==}
@@ -12592,7 +12592,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vite-powerflow/utils@0.0.1':
+  '@vite-powerflow/utils@0.0.2':
     dependencies:
       chalk: 5.4.1
       find-up: 7.0.0

--- a/scripts/git-utils.ts
+++ b/scripts/git-utils.ts
@@ -1,0 +1,48 @@
+import { execSync } from 'child_process';
+
+import { RELEASE_CONSTANTS } from '../constants/release-constants';
+
+/**
+ * Gets the latest release commit hash by searching for commits with release patterns.
+ * This should be the most recent "${RELEASE_CONSTANTS.COMMIT_MESSAGE}" or "${RELEASE_CONSTANTS.PR_TITLE}" commit.
+ *
+ * @param workspaceRoot - The root directory of the workspace
+ * @returns The SHA of the latest release commit, or HEAD if no release commit found
+ */
+export function getLatestReleaseCommit(workspaceRoot: string): string {
+  try {
+    // First, try to find the most recent release commit
+    const releaseCommit = execSync(
+      `git log --oneline --grep="${RELEASE_CONSTANTS.COMMIT_MESSAGE}" --grep="${RELEASE_CONSTANTS.PR_TITLE}" -1 --format="%H"`,
+      { encoding: 'utf-8', cwd: workspaceRoot }
+    ).trim();
+
+    if (releaseCommit) {
+      return releaseCommit;
+    } else {
+      // Fallback to HEAD if no release commit found
+      return execSync('git rev-parse HEAD', { encoding: 'utf-8', cwd: workspaceRoot }).trim();
+    }
+  } catch (error) {
+    throw new Error(
+      `Could not get git commit hash: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Gets the latest release commit hash and returns both the full SHA and short SHA.
+ *
+ * @param workspaceRoot - The root directory of the workspace
+ * @returns Object containing full SHA and short SHA (7 characters)
+ */
+export function getLatestReleaseCommitWithShort(workspaceRoot: string): {
+  full: string;
+  short: string;
+} {
+  const full = getLatestReleaseCommit(workspaceRoot);
+  return {
+    full,
+    short: full.substring(0, 7),
+  };
+}

--- a/scripts/set-cli-template-baseline.ts
+++ b/scripts/set-cli-template-baseline.ts
@@ -1,9 +1,9 @@
-import { execSync } from 'child_process';
 import fs from 'fs-extra';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 import { TemplatePkgJson } from './types/package-json';
+import { getLatestReleaseCommitWithShort } from './git-utils';
 import { logRootError, logRootInfo, logRootSuccess } from './monorepo-logger';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -27,10 +27,15 @@ void (async () => {
       process.exit(1);
     }
 
-    // Get the current git commit hash. This is the new baseline commit.
-    const commit = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
-    if (!commit) {
-      logRootError('Could not get current git commit hash.');
+    // Get the latest release commit hash using shared utility
+    let commit: string;
+    try {
+      const { full, short } = getLatestReleaseCommitWithShort(root);
+      commit = full;
+      logRootInfo(`Using latest release commit: ${short}`);
+    } catch (error) {
+      logRootError('Could not get git commit hash.');
+      logRootError(error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
 

--- a/scripts/sync-starter-to-template.ts
+++ b/scripts/sync-starter-to-template.ts
@@ -1,9 +1,9 @@
-import { execSync } from 'child_process';
 import fs from 'fs-extra';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 import { TemplatePkgJson } from './types/package-json';
+import { getLatestReleaseCommitWithShort } from './git-utils';
 import { logRootError, logRootInfo, logRootSuccess } from './monorepo-logger';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -117,22 +117,15 @@ void (async () => {
 
     // Add CLI template baseline commit metadata
     try {
-      const currentCommit = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+      // Get the latest release commit hash using shared utility
+      const { full, short } = getLatestReleaseCommitWithShort(root);
 
-      // PATCH: initialize starterSource with historic commit if missing
-      const HISTORIC_COMMIT = '668ab2e8f19ec5a066bfdba3e5f2713f29078ff5';
-      if (!pkg.starterSource) {
-        pkg.starterSource = {
-          commit: HISTORIC_COMMIT,
-          syncedAt: new Date().toISOString(),
-        };
-        logRootInfo('starterSource initialized with historic commit');
-      } else {
-        pkg.starterSource = {
-          commit: currentCommit,
-          syncedAt: new Date().toISOString(),
-        };
-      }
+      // Always update starterSource with the latest release commit
+      pkg.starterSource = {
+        commit: full,
+        syncedAt: new Date().toISOString(),
+      };
+      logRootInfo(`starterSource updated with commit: ${short}`);
     } catch {
       logRootInfo('Warning: Could not add CLI template baseline commit metadata');
     }


### PR DESCRIPTION
# Fix Starter package desynchronization

## Problem
Starter package showed as desynchronized because baseline calculation used `git rev-parse HEAD` instead of detecting the actual release commit created by Changesets.

## Solution
- Centralize release constants in `constants/release-constants.ts`
- Extract shared git utilities in `scripts/git-utils.ts`
- Update GitHub Actions to read constants dynamically
- Fix baseline calculation to detect latest release commit

## Changes
- `constants/release-constants.ts` (new)
- `scripts/git-utils.ts` (new)
- `.github/workflows/release.yml` (updated)
- `scripts/set-cli-template-baseline.ts` (refactored)
- `scripts/sync-starter-to-template.ts` (refactored)

## Testing
- ✅ All tests pass
- ✅ Manual testing performed
- ✅ No breaking changes
