### PR TITLE
fix: replace project name placeholders in project.json

### DIFF
--- a/.changeset/fix-project-json-placeholders.md
+++ b/.changeset/fix-project-json-placeholders.md
@@ -1,0 +1,12 @@
+---
+'@vite-powerflow/create': patch
+---
+
+fix: replace project name placeholders in project.json
+
+- Add step 9 to replace @vite-powerflow/starter with {{projectName}} in project.json
+- Replace buildTarget references with correct project name
+- Update step numbering for consistency
+- Ensures generated projects have correct Nx project configuration
+
+This fix ensures that when users create new projects with the CLI, the generated project.json file will have the correct project name instead of the hardcoded @vite-powerflow/starter references.


### PR DESCRIPTION
## 🐛 Fix: Project Name Placeholders in project.json

### 📖 Description
This PR fixes a critical issue where the generated `project.json` file in new projects still contained hardcoded references to `@vite-powerflow/starter` instead of using the actual project name.

### 🔧 Changes implemented
- **Added step 9** to replace `@vite-powerflow/starter` with `{{projectName}}` in project.json
- **Replace buildTarget references** with correct project name (`{{projectName}}:build`)
- **Update step numbering** for consistency in create.ts
- **Ensures generated projects** have correct Nx project configuration

### 🎯 Problem Solved
When users created new projects with the CLI, the generated `project.json` file would contain:
```json
{
  "name": "@vite-powerflow/starter",
  "targets": {
    "serve": {
      "options": {
        "buildTarget": "@vite-powerflow/starter:build"
      }
    }
  }
}
```

Now it correctly uses the actual project name:
```json
{
  "name": "my-awesome-project",
  "targets": {
    "serve": {
      "options": {
        "buildTarget": "my-awesome-project:build"
      }
    }
  }
}
```

### 🧪 Quality assurance
- [x] 🧪 BDD/TDD approach followed
- [x] ✅ Unit tests added/updated
- [x] 🔄 Integration tests added/updated
- [x] 🧠 Manual testing performed
- [x] 🔍 All existing tests pass
- [x] The code changes have been tested
- [x] All tests pass
- [x] Lint checks pass
- [x] Type checks pass
- [x] No breaking changes introduced

### 📦 Changeset
- **Package**: @vite-powerflow/create
- **Type**: patch (bug fix)
- **Impact**: Fixes project generation for all new projects

### 🔗 Related
This fix is part of the v2.0.0 Nx integration and ensures that generated projects have proper Nx configuration with correct project names.
