### PR TITLE
feat: sync CLI versioning improvements from dev to main

### DIFF
--- a/.changeset/cli-version-local-suffix.md
+++ b/.changeset/cli-version-local-suffix.md
@@ -1,0 +1,13 @@
+---
+'@vite-powerflow/create': patch
+---
+
+anchor: 5d47b22187957a572d1a4d60ab2f9a5e95f35e51
+
+Improve starter onboarding docs and CLI runtime version visibility.
+
+- Update starter README setup/prerequisites guidance for clearer onboarding
+- Show CLI version at startup for interactive runs
+- Detect local executions and append a `+local.<sha>[.dirty]` suffix
+- Keep npm-published execution versions clean (no local suffix)
+- Refactor version logic into a dedicated utility for maintainability

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-powerflow",
   "private": true,
-  "version": "1.1.0",
+  "version": "0.0.0",
   "description": "A React + Vite starter, fully containerized for reproducible and collaborative development, with strict code quality tooling and AI pair programming workflow (Cursor rules). Includes comprehensive testing, linting, and CI/CD configurations following industry best practices.",
   "author": {
     "name": "Shynn",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,14 +7,14 @@ Generate a new, production-ready [Vite PowerFlow](https://github.com/shynnobi/vi
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18 or higher)
-- [Cursor AI Editor](https://www.cursor.com) or [Visual Studio Code](https://code.visualstudio.com/)
-- [Docker](https://www.docker.com/)
-  > **Note:** For the best AI-assisted development experience, use [Cursor AI Editor](https://www.cursor.com).
-  > If you prefer a classic setup, [Visual Studio Code](https://code.visualstudio.com/) works perfectly.
+- Your favorite code editor
+- [pnpm](https://pnpm.io/) (or npm/yarn)
+- [Docker](https://www.docker.com/) (optional, for containerized development)
+- [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (optional, required only for Docker setup)
 
-### Generate an app using the CLI tool
+### Setup Steps
 
-1. Run this command in your terminal:
+1. **Create project with CLI:**
 
    ```bash
    npx @vite-powerflow/create my-app
@@ -22,21 +22,44 @@ Generate a new, production-ready [Vite PowerFlow](https://github.com/shynnobi/vi
 
    > You can also run the CLI tool in non-interactive mode for faster setup. See [CLI Options](#cli-options)
 
-2. Open the folder in your code editor
+2. **Open the folder in your code editor:**
 
-3. `Reopen in Container` when prompted (Dev Container)
+   ```bash
+   cd my-app
+   code .  # or open with your preferred editor
+   ```
 
-   ![DevContainer Prompt](https://www.dropbox.com/scl/fi/9rm4he8t53h9l30wz10vm/reopen-500.jpg?rlkey=dbrafybaezjnce85vj3b7p2jm&st=b22afec3&raw=1)
+3. **Choose your preferred development approach:**
 
-4. Wait for the installation (It can take a few minutes)
+#### 🐳 Docker Setup
 
-5. Launch dev server:
+If you installed the Dev Containers extension, you'll see a "Reopen in Container" prompt:
+
+1. Click `Reopen in Container` (or use the command palette)
+   - The first time, wait for the installation (can take a few minutes)
+   - On subsequent launches, you'll connect directly to the container
+
+2. Launch dev server:
 
    ```bash
    pnpm dev
    ```
 
-6. Start developing! 🚀
+#### 💻 Local Development
+
+1. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Launch dev server:
+
+   ```bash
+   pnpm dev
+   ```
+
+Start developing! 🚀
 
 <hr>
 
@@ -54,8 +77,10 @@ The CLI tool supports the following options for non-interactive usage:
 
 ## Documentation
 
-For full documentation, features, and advanced usage, see the [Vite PowerFlow monorepo README](https://github.com/shynnobi/vite-powerflow#readme).
-(WIP: Vite Powerflow website coming soon )
+- **Website:** [vite-powerflow.netlify.app](https://vite-powerflow.netlify.app/)
+- **GitHub:** [Vite PowerFlow monorepo](https://github.com/shynnobi/vite-powerflow#readme)
+
+For full documentation, features, and advanced usage, visit the official website or explore the repository.
 
 ---
 

--- a/packages/cli/build.ts
+++ b/packages/cli/build.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { logError, logInfo, logSuccess } from './src/utils/shared/logger.js';
+import { endGroup, logError, logInfo, logSuccess, startGroup } from './src/utils/shared/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,7 +13,7 @@ async function cleanDist(): Promise<void> {
   const distPath = path.join(__dirname, 'dist');
   if (await fs.pathExists(distPath)) {
     await fs.remove(distPath);
-    logInfo('🧹 Cleaned dist directory');
+    logInfo('Cleaning output directory');
   }
 }
 
@@ -23,7 +23,7 @@ async function copyTemplate(): Promise<void> {
   const distTemplatePath = path.join(__dirname, 'dist', 'template');
 
   try {
-    logInfo('Copying template to packages/cli/dist...');
+    logInfo('Bundling template');
 
     // Ensure dist directory exists
     await fs.ensureDir(path.dirname(distTemplatePath));
@@ -58,7 +58,7 @@ void (async () => {
   const templatePath = path.join(__dirname, 'template');
 
   try {
-    logInfo('Building the CLI tool...');
+    startGroup('Building the Vite PowerFlow CLI');
 
     // 1. Clean dist directory
     await cleanDist();
@@ -99,8 +99,10 @@ void (async () => {
       logLevel: 'info',
     });
 
-    logSuccess('CLI tool built successfully!');
+    endGroup();
+    logSuccess('Vite PowerFlow CLI built successfully');
   } catch (err) {
+    endGroup();
     logError('Build failed');
     if (err instanceof Error) {
       logError(err.message);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,15 +1,20 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
 import { Command } from 'commander';
-import fs from 'fs/promises';
+import { promises as fsPromises } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { createProject } from './commands/create.js';
+import { getCliVersion } from './utils/cli-version.js';
 import { directoryExists } from './utils/fs-utils.js';
 import { promptProjectName } from './utils/prompt-ui.js';
 import { safePackageName } from './utils/safe-package-name.js';
 import { logError } from './utils/shared/logger.js';
 import type { GitOptions } from '../types/git-options.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 let currentProjectPath: string | null = null;
 let isCleaningUp = false;
@@ -25,7 +30,7 @@ async function cleanup() {
 
   if (currentProjectPath) {
     try {
-      await fs.rm(currentProjectPath, { recursive: true, force: true });
+      await fsPromises.rm(currentProjectPath, { recursive: true, force: true });
     } catch {
       // Ignore cleanup errors
     }
@@ -44,7 +49,7 @@ process.stdin.on('keypress', (_: string, key: { ctrl: boolean; name: string }) =
 
 const program = new Command()
   .name('@vite-powerflow/create')
-  .version(process.env.npm_package_version || '1.0.4')
+  .version(getCliVersion())
   .argument(
     '[project-directory]',
     'The name of the project directory (optional in interactive mode)'
@@ -57,6 +62,16 @@ const program = new Command()
     'after',
     '\nExamples:\n  $ npx @vite-powerflow/create              # Interactive mode\n  $ npx @vite-powerflow/create my-app       # Non-interactive with project name\n  $ npx @vite-powerflow/create my-app --git # With Git initialization'
   );
+
+const cliVersion = getCliVersion();
+
+function shouldShowStartupVersionBanner(args: string[]): boolean {
+  return !args.includes('--version') && !args.includes('-V') && !args.includes('--help');
+}
+
+if (shouldShowStartupVersionBanner(process.argv)) {
+  console.log(`Using @vite-powerflow/create ${cliVersion}`);
+}
 
 program.parse(process.argv);
 const cliOptions = program.opts<GitOptions>();

--- a/packages/cli/src/utils/cli-version.ts
+++ b/packages/cli/src/utils/cli-version.ts
@@ -1,0 +1,101 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+interface CliPackageJson {
+  name?: string;
+  version?: string;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function getCliVersion(): string {
+  const cliRoot = findCliRoot();
+  const baseVersion = readBaseVersion();
+  const localSuffix = isLocalExecutionContext() ? getLocalBuildSuffix(cliRoot) : '';
+  return `${baseVersion}${localSuffix}`;
+}
+
+function isLocalExecutionContext(): boolean {
+  return !__dirname.includes(`${path.sep}node_modules${path.sep}`);
+}
+
+function readBaseVersion(): string {
+  try {
+    const cliRoot = findCliRoot();
+    if (!cliRoot) {
+      return '0.0.0';
+    }
+
+    const packageJsonPath = path.join(cliRoot, 'package.json');
+    const packageJson = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageData = JSON.parse(packageJson) as CliPackageJson;
+    return packageData.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function findCliRoot(): string | null {
+  const candidates = [
+    path.join(__dirname, '..'),
+    path.join(__dirname, '..', '..'),
+    path.join(__dirname, '..', '..', '..'),
+  ];
+
+  for (const candidate of candidates) {
+    const packageJsonPath = path.join(candidate, 'package.json');
+    if (!fs.existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    try {
+      const packageJson = fs.readFileSync(packageJsonPath, 'utf-8');
+      const packageData = JSON.parse(packageJson) as CliPackageJson;
+      if (packageData.name === '@vite-powerflow/create') {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function getLocalBuildSuffix(cliRoot: string | null): string {
+  if (!cliRoot) {
+    return '';
+  }
+
+  const gitRoot = path.join(cliRoot, '..', '..', '.git');
+
+  if (!fs.existsSync(gitRoot)) {
+    return '';
+  }
+
+  try {
+    const shortSha = execSync('git rev-parse --short HEAD', {
+      cwd: cliRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+
+    const dirty =
+      execSync('git status --porcelain', {
+        cwd: cliRoot,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim().length > 0;
+
+    if (shortSha.length === 0) {
+      return '+local';
+    }
+
+    return dirty ? `+local.${shortSha}.dirty` : `+local.${shortSha}`;
+  } catch {
+    return '+local';
+  }
+}

--- a/packages/cli/src/utils/shared/logger.ts
+++ b/packages/cli/src/utils/shared/logger.ts
@@ -2,24 +2,49 @@ import chalk from 'chalk';
 import ora, { type Ora } from 'ora';
 
 /**
+ * Simple depth tracking for indentation
+ */
+let indent_depth = 0;
+
+function getIndent(): string {
+  return '  '.repeat(indent_depth);
+}
+
+/**
  * CLI-style logging functions
  * These are always shown regardless of environment
  */
 export function logInfo(msg: string) {
-  console.log(chalk.cyan('❯'), msg);
+  console.log(`${getIndent()}${chalk.cyan('›')} ${msg}`);
 }
 
 export function logSuccess(msg: string) {
-  console.log(chalk.green('✔'), msg);
+  console.log(`${getIndent()}${chalk.green('✓')} ${msg}`);
 }
 
 export function logError(msg: string) {
-  console.error(chalk.red('✖'), msg);
+  console.error(`${getIndent()}${chalk.red('✖')} ${msg}`);
+}
+
+export function logDetail(msg: string) {
+  console.log(`${getIndent()}${chalk.gray('→')} ${msg}`);
+}
+
+/**
+ * Task grouping for hierarchical output
+ */
+export function startGroup(title: string) {
+  console.log(`\n${getIndent()}${chalk.bold(title)}`);
+  indent_depth++;
+}
+
+export function endGroup() {
+  indent_depth = Math.max(0, indent_depth - 1);
 }
 
 /**
  * Creates a spinner for long-running operations
  */
 export function createSpinner(text: string): Ora {
-  return ora({ text, spinner: 'dots' }).start();
+  return ora({ text, spinner: 'dots', prefixText: getIndent() }).start();
 }

--- a/scripts/inline-shared-utils.ts
+++ b/scripts/inline-shared-utils.ts
@@ -4,6 +4,8 @@ import { glob } from 'glob';
 import { builtinModules } from 'module';
 import path from 'path';
 
+import { logger, logRootDetail } from './monorepo-logger';
+
 const SHARED_UTILS = 'packages/shared-utils/src';
 const SHARED_UTILS_PACKAGE_JSON = 'packages/shared-utils/package.json';
 
@@ -14,10 +16,8 @@ function getConsumers(): string[] {
   // All packages that use shared utilities
   const consumers = ['apps/starter', 'packages/cli', 'packages/vite-powerflow-sync'];
 
-  console.log('🔍 Making packages autonomous by inlining shared utilities...');
-  for (const consumer of consumers) {
-    console.log(`  📦 Target consumer: ${consumer}`);
-  }
+  logger.startGroup('Making packages autonomous by inlining shared utilities');
+  logger.detail(`Target consumers: ${consumers.join(', ')}`);
 
   return consumers;
 }
@@ -58,7 +58,7 @@ function getImportExtension(consumer: string): string {
     // Default fallback
     return '';
   } catch {
-    console.log(`⚠️  Could not read package.json for ${consumer}, using default import extension`);
+    logger.warn(`Could not read package.json for ${consumer}, using default import extension`);
     return '';
   }
 }
@@ -135,25 +135,25 @@ function extractExports(content: string): string[] {
 }
 
 async function inlineSharedUtils(): Promise<void> {
-  console.log('🔄 Inlining shared utilities...');
+  logger.info('Inlining shared utilities');
 
   // Get required dependencies from shared-utils (will be calculated per consumer)
-  console.log('📦 Dependencies will be extracted per consumer based on used files...');
+  logger.detail('Dependencies will be extracted per consumer based on used files');
 
   // Automatically detect all mappings
   const importMappings = await autoDetectAllMappings();
-  console.log(`📋 Detected ${importMappings.length} modules to inline`);
+  logger.detail(`Detected ${importMappings.length} modules to inline`);
 
   // Get consumers (hybrid approach)
   const consumers = getConsumers();
 
   for (const consumer of consumers) {
     if (!existsSync(consumer)) {
-      console.log(`⏭️  Skipping ${consumer} (not found)`);
+      logRootDetail(`Skipping ${consumer} (not found)`);
       continue;
     }
 
-    console.log(`📦 Processing ${consumer}...`);
+    logger.detail(`Processing ${consumer}`);
 
     const targetDir = `${consumer}/src/utils/shared`;
 
@@ -186,9 +186,12 @@ async function inlineSharedUtils(): Promise<void> {
     }
 
     if (usedFiles.size === 0) {
-      console.log(`  ℹ️  No shared-utils usage found for ${consumer}`);
+      logRootDetail(`No shared-utils usage found for ${consumer}`);
+      logger.endGroup();
       continue;
     }
+
+    logger.startGroup(`Processing ${consumer}`);
 
     // Create the destination directory only when needed
     mkdirSync(targetDir, { recursive: true });
@@ -200,7 +203,7 @@ async function inlineSharedUtils(): Promise<void> {
 
       if (existsSync(sourceFile)) {
         copyFileSync(sourceFile, targetFile);
-        console.log(`  ✅ Copied ${file}`);
+        logger.detail(`Copied ${file}`);
       }
     }
 
@@ -230,19 +233,21 @@ async function inlineSharedUtils(): Promise<void> {
 
       if (modified) {
         writeFileSync(file, content);
-        console.log(`  🔄 Updated imports in ${path.relative(consumer, file)}`);
+        logger.detail(`Updated imports in ${path.relative(consumer, file)}`);
       }
     }
 
     // Update dependencies in package.json based on actually used files
-    console.log(`📦 Updating dependencies for ${consumer}...`);
+    logger.detail(`Updating dependencies for ${consumer}`);
     const requiredDeps = getRequiredDependencies(usedFiles);
     updateConsumerDependencies(consumer, requiredDeps);
 
-    console.log(`✅ Completed ${consumer}`);
+    logger.success(`Completed ${consumer}`);
+    logger.endGroup();
   }
 
-  console.log('🎉 Shared utilities inlining completed!');
+  logger.endGroup();
+  logger.success('Shared utilities inlining completed');
 }
 
 function extractImportedFunctions(content: string, importPath: string): string[] {
@@ -290,7 +295,7 @@ function extractImportedFunctions(content: string, importPath: string): string[]
  */
 function getRequiredDependencies(usedFiles: Set<string>): Record<string, string> {
   if (!existsSync(SHARED_UTILS_PACKAGE_JSON)) {
-    console.log('❌ Shared utils package.json not found, skipping dependency copying');
+    logger.error('Shared utils package.json not found, skipping dependency copying');
     return {};
   }
 
@@ -301,7 +306,7 @@ function getRequiredDependencies(usedFiles: Set<string>): Record<string, string>
 
   // Only detect dependencies for files that are actually being inlined
   const usedDependencies = detectUsedDependenciesForFiles(usedFiles);
-  console.log(`🔍 Detected used dependencies for inlined files: ${usedDependencies.join(', ')}`);
+  logger.detail(`Detected used dependencies for inlined files: ${usedDependencies.join(', ')}`);
 
   // Only return dependencies that are actually used in the inlined files
   const requiredDeps: Record<string, string> = {};
@@ -404,7 +409,7 @@ function updateConsumerDependencies(consumer: string, requiredDeps: Record<strin
   const packageJsonPath = `${consumer}/package.json`;
 
   if (!existsSync(packageJsonPath)) {
-    console.log(`❌ Package.json not found for ${consumer}, skipping dependency update`);
+    logger.error(`Package.json not found for ${consumer}, skipping dependency update`);
     return;
   }
 
@@ -423,22 +428,22 @@ function updateConsumerDependencies(consumer: string, requiredDeps: Record<strin
     if (!currentVersion || currentVersion !== depVersion) {
       packageJson.dependencies[depName] = depVersion;
       hasChanges = true;
-      console.log(`  ✅ Added/updated dependency: ${depName}@${depVersion}`);
+      logger.detail(`Added/updated dependency: ${depName}@${depVersion}`);
     }
   }
 
   if (hasChanges) {
     writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-    console.log(`  ✅ Updated package.json for ${consumer}`);
+    logger.detail(`Updated package.json for ${consumer}`);
   } else {
-    console.log(`  ℹ️  No dependency changes needed for ${consumer}`);
+    logger.detail(`No dependency changes needed for ${consumer}`);
   }
 }
 
 // Execute the script
 if (import.meta.url === `file://${process.argv[1]}`) {
   inlineSharedUtils().catch(error => {
-    console.error(`❌ Script failed: ${error instanceof Error ? error.message : String(error)}`);
+    logger.error(`Script failed: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   });
 }

--- a/scripts/monorepo-logger.ts
+++ b/scripts/monorepo-logger.ts
@@ -1,18 +1,103 @@
 import chalk from 'chalk';
 import ora, { Ora } from 'ora';
 
+/**
+ * Logging levels for the monorepo
+ * silent: No output
+ * error: Only errors
+ * warn: Errors and warnings
+ * normal: Standard output (default)
+ * verbose: Detailed output with nested levels
+ */
+export type LogLevel = 'silent' | 'error' | 'warn' | 'normal' | 'verbose';
+
+class MonorepoLogger {
+  private level: LogLevel = 'normal';
+  private depth = 0;
+
+  constructor() {
+    // Check for --verbose flag
+    if (process.argv.includes('--verbose')) {
+      this.level = 'verbose';
+    }
+  }
+
+  setLevel(level: LogLevel) {
+    this.level = level;
+  }
+
+  private indent(): string {
+    return '  '.repeat(this.depth);
+  }
+
+  // Main logging methods
+  info(msg: string) {
+    if (this.level === 'silent') return;
+    console.log(`${this.indent()}${chalk.cyan('›')} ${msg}`);
+  }
+
+  success(msg: string) {
+    if (this.level === 'silent') return;
+    console.log(`${this.indent()}${chalk.green('✓')} ${msg}`);
+  }
+
+  error(msg: string) {
+    // Errors always show
+    console.error(`${this.indent()}${chalk.red('✖')} ${msg}`);
+  }
+
+  warn(msg: string) {
+    if (this.level === 'silent') return;
+    console.warn(`${this.indent()}${chalk.yellow('⚠')} ${msg}`);
+  }
+
+  // Verbose mode details
+  detail(msg: string) {
+    if (this.level !== 'verbose') return;
+    console.log(`${this.indent()}${chalk.gray('→')} ${msg}`);
+  }
+
+  // Task group
+  startGroup(title: string) {
+    if (this.level === 'silent') return;
+    console.log(`\n${this.indent()}${chalk.bold(title)}`);
+    this.depth++;
+  }
+
+  endGroup() {
+    if (this.level === 'silent') return;
+    this.depth = Math.max(0, this.depth - 1);
+  }
+
+  // Create a spinner (task runner)
+  createSpinner(text: string): Ora {
+    if (this.level === 'silent') {
+      return ora({ text, isEnabled: false }).start();
+    }
+    return ora({ text, spinner: 'dots3', prefixText: this.indent() }).start();
+  }
+}
+
+// Export singleton instance
+export const logger = new MonorepoLogger();
+
+// Legacy exports for backwards compatibility
 export function createRootSpinner(text: string): Ora {
-  return ora({ text, spinner: 'dots' }).start();
+  return logger.createSpinner(text);
 }
 
 export function logRootInfo(msg: string) {
-  console.log(chalk.cyan('❯'), msg);
+  logger.info(msg);
 }
 
 export function logRootSuccess(msg: string) {
-  console.log(chalk.green('✔'), msg);
+  logger.success(msg);
 }
 
 export function logRootError(msg: string) {
-  console.error(chalk.red('✖'), msg);
+  logger.error(msg);
+}
+
+export function logRootDetail(msg: string) {
+  logger.detail(msg);
 }

--- a/scripts/sync-starter-to-template.ts
+++ b/scripts/sync-starter-to-template.ts
@@ -4,7 +4,12 @@ import { glob } from 'glob';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-import { logRootError, logRootInfo, logRootSuccess } from './monorepo-logger';
+import {
+  logger,
+  logRootError as _logRootError,
+  logRootInfo as _logRootInfo,
+  logRootSuccess as _logRootSuccess,
+} from './monorepo-logger';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,20 +37,21 @@ void (async () => {
   const starterSrc = path.join(root, 'apps/starter');
   const templateDest = path.join(root, 'packages/cli/template');
 
-  logRootInfo('—— Sync apps/starter to packages/cli/template ——');
+  logger.startGroup('Sync apps/starter to packages/cli/template');
   try {
     // 0. Ensure shared-utils are inlined in the starter before copying
-    logRootInfo('Ensuring shared-utils are inlined in starter...');
+    logger.info('Inlining utilities into app');
     execSync('pnpm inline:shared-utils', {
       cwd: root,
-      stdio: 'inherit',
+      stdio: ['pipe', 'pipe', 'inherit'], // Hide pnpm stdout/stderr, show only errors
     });
+
     // 1. Remove any existing template directory before copying
-    logRootInfo('Deleting existing template folder...');
+    logger.info('Clearing template cache');
     await fs.remove(templateDest);
 
     // 2. Copy the starter app to the template destination
-    logRootInfo('Copying folders...');
+    logger.info('Syncing starter → template');
     await fs.copy(starterSrc, templateDest, {
       filter: (srcPath: string) => {
         const ignore = [
@@ -85,16 +91,14 @@ void (async () => {
 
     // 3. Ensure the template directory exists after copy
     if (!(await fs.pathExists(templateDest))) {
-      logRootError(
+      logger.error(
         'Failed to copy the template directory. Please check the source and destination paths.'
       );
       process.exit(1);
     }
 
     // 4. Patch package.json: update scripts, add metadata, and replace workspace deps
-    logRootInfo(
-      'Patching package.json: scripts, metadata, and replacing workspace dependencies...'
-    );
+    logger.info('Updating dependencies & scripts');
     const pkgPath = path.join(templateDest, 'package.json');
     const pkgRaw = await fs.readFile(pkgPath, 'utf8');
     const pkg = JSON.parse(pkgRaw) as {
@@ -115,7 +119,7 @@ void (async () => {
         if (typeof version === 'string' && version.startsWith('workspace:')) {
           // Skip @vite-powerflow/shared-utils as it will be inlined
           if (name === '@vite-powerflow/shared-utils') {
-            logRootInfo(`  - Skipping ${name} (will be inlined)`);
+            logger.detail(`Skipping ${name} (will be inlined)`);
             continue;
           }
 
@@ -131,15 +135,15 @@ void (async () => {
             // Remove @vite-powerflow/shared-utils completely as it will be inlined
             if (key === '@vite-powerflow/shared-utils') {
               delete deps[key];
-              logRootInfo(`  - Removed ${key} (will be inlined)`);
+              logger.detail(`Removed ${key} (will be inlined)`);
               continue;
             }
 
             if (depsToReplace[key]) {
               deps[key] = depsToReplace[key];
-              logRootInfo(`  - Replaced ${key} with version ${depsToReplace[key]}`);
+              logger.detail(`Replaced ${key} with version ${depsToReplace[key]}`);
             } else {
-              logRootInfo(`  - Warning: workspace dependency ${key} not found in replacement map.`);
+              logger.warn(`Workspace dependency ${key} not found in replacement map`);
             }
           }
         }
@@ -148,13 +152,13 @@ void (async () => {
       replaceWorkspaceDeps(pkg.dependencies as Record<string, string> | undefined);
       replaceWorkspaceDeps(pkg.devDependencies as Record<string, string> | undefined);
     } catch (versionError) {
-      logRootError('Failed to replace workspace dependencies.');
-      logRootError(versionError instanceof Error ? versionError.message : String(versionError));
+      logger.error('Failed to replace workspace dependencies');
+      logger.error(versionError instanceof Error ? versionError.message : String(versionError));
       process.exit(1);
     }
 
     // 5. Clean tsconfig.json by removing 'extends' for standalone usage
-    logRootInfo("Cleaning tsconfig.json (removing 'extends')...");
+    logger.info('Configuring TypeScript');
     const tsconfigPath = path.join(templateDest, 'tsconfig.json');
     if (await fs.pathExists(tsconfigPath)) {
       const tsconfigRaw = await fs.readFile(tsconfigPath, 'utf-8');
@@ -166,7 +170,7 @@ void (async () => {
     }
 
     // 6. Transform project.json files to use template-compatible names
-    logRootInfo('Patching project.json files for template usage...');
+    logger.info('Updating NX project names');
     const projectJsonFiles = await glob(path.join(templateDest, '**/project.json'), { dot: true });
     for (const projectJsonFile of projectJsonFiles) {
       try {
@@ -178,12 +182,10 @@ void (async () => {
         if (projectName?.startsWith('@vite-powerflow/')) {
           proj.name = projectName.replace('@vite-powerflow/', '@template-app/');
           await fs.writeFile(projectJsonFile, JSON.stringify(proj, null, 2) + '\n', 'utf-8');
-          logRootInfo(
-            `  - Updated project name in ${path.relative(templateDest, projectJsonFile)}`
-          );
+          logger.detail(`Updated project name in ${path.relative(templateDest, projectJsonFile)}`);
         }
       } catch (e) {
-        logRootError(`Failed to patch ${projectJsonFile}: ${e}`);
+        logger.error(`Failed to patch ${projectJsonFile}: ${e}`);
       }
     }
 
@@ -192,7 +194,7 @@ void (async () => {
     const isRootPackage = pkgPath === path.join(templateDest, 'package.json');
 
     if (isRootPackage) {
-      logRootInfo('Patching root package.json scripts from starter SSOT...');
+      logger.info('Syncing package scripts');
       const starterPkgPath = path.join(starterSrc, 'package.json');
       const starterPkgRaw = await fs.readFile(starterPkgPath, 'utf8');
       const starterPkg = JSON.parse(starterPkgRaw) as {
@@ -212,12 +214,14 @@ void (async () => {
         ...(starterPkg.devDependencies ?? {}),
       };
 
-      logRootInfo('  - Root scripts now mirror starter package.json (SSOT)');
+      logger.detail('Root scripts now mirror starter package.json (SSOT)');
     }
-    logRootSuccess('Template synchronized successfully!');
+    logger.endGroup();
+    logger.success('Template synchronized successfully');
   } catch (err) {
-    logRootError('Template synchronization failed!');
-    logRootError(err instanceof Error ? err.message : String(err));
+    logger.endGroup();
+    logger.error('Template synchronization failed');
+    logger.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Sync Summary

This PR syncs the CLI versioning and runtime labeling improvements from `dev` to `main` for release. It includes changes merged in PR #264 "fix(cli): clarify local runtime version labeling".

### Source Branch Coverage

- feat/cli-logging-and-build-improvements → dev (merged as #264)

### Changes Being Synced

#### 🚀 CLI Versioning

- Display CLI version at startup for interactive runs
- Add local execution suffix format: `+local.<sha>[.dirty]`
- Keep npm-installed CLI version output clean (no local suffix)

#### ♻️ Refactor & Tooling

- Extract version resolution into `packages/cli/src/utils/cli-version.ts`
- Freeze root workspace metadata version to `0.0.0`
- Apply lint-driven fixes required by pre-commit hooks

#### 📚 Documentation

- Update starter README setup and prerequisites guidance
- Update changeset notes to reflect README + CLI scope

### Release Impact

This sync carries the CLI runtime version-labeling improvements to `main` for the next release flow.

_This is a sync PR following the monorepo branch topology (`dev` → `main`)._
